### PR TITLE
Fix: Correct import paths in game-graphics

### DIFF
--- a/game-graphics/AppShell.tsx
+++ b/game-graphics/AppShell.tsx
@@ -10,7 +10,7 @@ import {
 import { FIRST_TRAIT_LEVEL, TRAIT_LEVEL_INTERVAL } from '../constants';
 
 // Import layout and modal components
-import MainLayout from '../src/layouts/MainLayout';
+import MainLayout from '../layouts/MainLayout';
 import Modal from '../components/Modal';
 import { CharacterSheetModal } from '../components/CharacterSheetModal';
 import HelpWikiModal from '../components/HelpWikiModal';

--- a/game-graphics/ViewRouter.tsx
+++ b/game-graphics/ViewRouter.tsx
@@ -19,12 +19,12 @@ import {
 // Import all view components
 import HomeScreenView from '../components/HomeScreenView';
 import CampView from '../components/CampView';
-import HomesteadView from '../src/components/HomesteadView';
-import SettlementView from '../src/components/SettlementView';
-import ShopView from '../src/components/ShopView';
-import NPCsView from '../src/components/NPCsView';
-import RecipeDiscoveryView from '../src/components/RecipeDiscoveryView';
-import CraftingWorkshopView from '../src/components/CraftingWorkshopView';
+import HomesteadView from '../components/HomesteadView';
+import SettlementView from '../components/SettlementView';
+import ShopView from '../components/ShopView';
+import NPCsView from '../components/NPCsView';
+import RecipeDiscoveryView from '../components/RecipeDiscoveryView';
+import CraftingWorkshopView from '../components/CraftingWorkshopView';
 import SpellCraftingView from '../components/SpellCraftingView';
 import SpellDesignStudioView from '../components/SpellDesignStudioView';
 import ResearchLabView from '../components/ResearchLabView';


### PR DESCRIPTION
I corrected several import paths in `game-graphics/AppShell.tsx` and `game-graphics/ViewRouter.tsx` that were pointing to a non-existent `src` directory. This resolves potential "module not found" errors and ensures the application can load these components correctly.