### PR TITLE
Fix: Correct path for camp card GIF in HomeScreenView

### DIFF
--- a/src/components/HomeScreenView.tsx
+++ b/src/components/HomeScreenView.tsx
@@ -49,7 +49,7 @@ const HomeScreenView: React.FC<HomeScreenViewProps> = ({
       color: 'from-amber-500/20 to-amber-600/20',
       borderColor: 'border-amber-500/30',
       iconColor: 'text-amber-400',
-      backgroundImage: 'camp.gif'
+      backgroundImage: '/assets/activity-card/camp.gif'
     },
     {
       id: 'research',


### PR DESCRIPTION
The camp card GIF on the homescreen was not displaying because its `backgroundImage` path was set to a relative 'camp.gif' instead of an absolute path from the public directory.

This change updates the path to '/assets/activity-card/camp.gif', aligning it with the path structure used for other activity card images, ensuring the GIF is correctly loaded and displayed.