### PR TITLE
Fix: Correct Damage Modifier precedence in constants.ts.

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -510,17 +510,22 @@ export const TAG_DEFINITIONS: { [key in TagName]: TagDefinition } = {
     effectType: "trigger", // Was 'passive'
     unlockLevel: 4,
   },
-  Piercing: { name: 'Piercing', description: 'Ignores a portion of target armor/resistance.', category: TagCategory.DAMAGE_MODIFIER, color: 'grey', rarity: 3, powerLevel: 4, synergizesWith: ['Projectile', 'Physical'], unlockLevel: 3, effectType: 'modifier' },
-  Armor_Ignoring: { name: 'Armor_Ignoring', description: 'Completely bypasses all armor and resistances.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkred', rarity: 7, powerLevel: 8, conflictsWith: ["Piercing", "True_Damage"], unlockLevel: 12, effectType: 'modifier' },
+  // Armor Penetration - Ordered by precedence: True_Damage > Armor_Ignoring > Piercing
   True_Damage: { name: 'True_Damage', description: 'Damage that cannot be mitigated by armor or resistances.', category: TagCategory.DAMAGE_MODIFIER, color: 'lightgrey', rarity: 7, powerLevel: 9, conflictsWith: ["Piercing", "Armor_Ignoring"], unlockLevel: 18, effectType: 'modifier' },
+  Armor_Ignoring: { name: 'Armor_Ignoring', description: 'Completely bypasses all armor and resistances.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkred', rarity: 7, powerLevel: 8, conflictsWith: ["Piercing", "True_Damage"], unlockLevel: 12, effectType: 'modifier' },
+  Piercing: { name: 'Piercing', description: 'Ignores a portion of target armor/resistance.', category: TagCategory.DAMAGE_MODIFIER, color: 'grey', rarity: 3, powerLevel: 4, conflictsWith: ["True_Damage", "Armor_Ignoring"], synergizesWith: ['Projectile', 'Physical'], unlockLevel: 3, effectType: 'modifier' },
+
+  // Damage Boost - Ordered by precedence: Devastating > Brutal > Overwhelming
+  Devastating: { name: 'Devastating', description: 'Massively increases damage, potentially with a drawback or high cost.', category: TagCategory.DAMAGE_MODIFIER, color: 'black', rarity: 8, powerLevel: 0, conflictsWith: ["Brutal", "Overwhelming"], effectType: 'modifier', unlockLevel: 15 },
+  Brutal: { name: 'Brutal', description: 'Increases base damage significantly.', category: TagCategory.DAMAGE_MODIFIER, color: 'brown', rarity: 4, powerLevel: 0, conflictsWith: ["Devastating", "Overwhelming"], synergizesWith: ['Critical', 'Physical'], effectType: 'modifier', unlockLevel: 7 },
+  Overwhelming: { name: 'Overwhelming', description: 'Slightly increases damage and may add a minor secondary effect.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkred', rarity: 3, powerLevel: 0, conflictsWith: ["Devastating", "Brutal"], effectType: 'modifier', unlockLevel: 9 },
+
+  // Other Damage Modifiers
   Percentage_Damage: { name: 'Percentage_Damage', description: 'Deals damage equal to a percentage of the target\'s max or current health.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkpurple', rarity: 6, powerLevel: 0, unlockLevel: 10, effectType: 'modifier' },
   Explosive: { name: 'Explosive', description: 'Deals area damage around the primary target upon impact.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkorange', rarity: 5, powerLevel: 0, synergizesWith: ['Fire', 'AreaOfEffect'], effectType: 'trigger', unlockLevel: 5 },
   Cleave: { name: 'Cleave', description: 'Attack hits multiple enemies in front of the attacker.', category: TagCategory.DAMAGE_MODIFIER, color: 'maroon', rarity: 3, powerLevel: 4, synergizesWith: ['Physical', 'Melee'], unlockLevel: 3, effectType: 'modifier' },
-  Brutal: { name: 'Brutal', description: 'Increases base damage significantly.', category: TagCategory.DAMAGE_MODIFIER, color: 'brown', rarity: 4, powerLevel: 0, synergizesWith: ['Critical', 'Physical'], effectType: 'modifier', unlockLevel: 7 },
-  Overwhelming: { name: 'Overwhelming', description: 'Slightly increases damage and may add a minor secondary effect.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkred', rarity: 3, powerLevel: 0, effectType: 'modifier', unlockLevel: 9 },
   Penetrating: { name: 'Penetrating', description: 'Passes through magical shields and barriers.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkcyan', rarity: 5, powerLevel: 5, synergizesWith: ['Arcane'], unlockLevel: 7, effectType: 'modifier' },
   Shattering: { name: 'Shattering', description: 'Destroys armor and shields on critical hits.', category: TagCategory.DAMAGE_MODIFIER, color: 'darkblue', rarity: 5, powerLevel: 6, synergizesWith: ['Ice', 'Critical'], unlockLevel: 8, effectType: 'trigger' },
-  Devastating: { name: 'Devastating', description: 'Massively increases damage, potentially with a drawback or high cost.', category: TagCategory.DAMAGE_MODIFIER, color: 'black', rarity: 8, powerLevel: 0, conflictsWith: ["Brutal", "Overwhelming"], effectType: 'modifier', unlockLevel: 15 },
 
   // Healing & Support
   Healing: {

--- a/documentation/bugreporting.md
+++ b/documentation/bugreporting.md
@@ -1,0 +1,66 @@
+# Bug Report & Tag System Analysis Summary
+
+This document summarizes key findings from an analysis of the Tag System, primarily focusing on `constants.ts` (TAG_DEFINITIONS) and its interaction with `TagSystem.ts` and `CombatEngine.ts`.
+
+## Major Issues Requiring Fixes:
+
+### 1. Precedence and Conflict Issues in `TAG_DEFINITIONS`
+
+The order of tags in `TAG_DEFINITIONS` dictates precedence. Several categories have logical errors:
+
+*   **Damage Modifiers (Partially Addressed):**
+    *   **Issue:** `Piercing` (weaker armor penetration) had precedence over `Armor_Ignoring` and `True_Damage`. `Brutal`/`Overwhelming` (weaker damage boosts) had precedence over `Devastating`.
+    *   **Attempted Fix (in this task):** Reordered these specific tags (`True_Damage`, `Armor_Ignoring`, `Piercing` and `Devastating`, `Brutal`, `Overwhelming`) to reflect logical hierarchy. Ensured their `conflictsWith` properties are robust.
+    *   **Further Action:** Verify these changes thoroughly in testing.
+
+*   **Rarity Tags (Critical):**
+    *   **Issue:** Tags like `Common`, `Rare`, `Legendary`, etc., do **not** conflict with each other. They should be mutually exclusive.
+    *   **Recommendation:** Add `conflictsWith` to each rarity tag, listing all other rarity tags. Then, reorder these tags within `constants.ts` so that the highest actual rarity (e.g., `Cosmic`) has the highest game precedence (appears earliest in the Rarity block).
+
+*   **Tiered Debuffs (e.g., Confusion/Madness):**
+    *   **Issue:** Weaker versions (`Confusion`, `Fatigue`) have higher precedence than stronger versions (`Madness`, `Exhaustion`).
+    *   **Recommendation:** Reorder these pairs and ensure they conflict with each other. Stronger version should have higher precedence.
+
+*   **Tiered Vampiric Tags (Lifesteal/Vampiric):**
+    *   **Issue:** `Lifesteal` (weaker) has higher precedence than `Vampiric` (stronger).
+    *   **Recommendation:** Reorder and ensure they conflict (conflict already exists).
+
+*   **Tiered Damage Over Time Tags (e.g., Corroding/Dissolving):**
+    *   **Issue:** Weaker versions can have higher precedence than stronger versions.
+    *   **Recommendation:** Review pairs like `Corroding`/`Dissolving` and `Withering`/`Decaying`. Reorder and ensure they conflict if tiered.
+
+### 2. Missing `conflictsWith` Entries
+
+*   **Targeting Tags:** `GlobalTarget`, `RandomTarget`, `Touch` are missing logical conflicts with more specific or contradictory targeting types (e.g., `GlobalTarget` should likely conflict with `Melee`; `Touch` with `Ranged`).
+*   **Spell Property Tags:** `Persistent`, `Toggle`, `Concentration` lack some logical conflicts with other casting/duration modes (e.g., an `Instant` direct damage spell probably shouldn't also have `Concentration`). `Ritual` could also conflict with `Channeling`/`Delayed`.
+*   **Defensive Mechanics:** `Block`, `Parry`, `Dodge` should likely conflict as they are distinct defensive actions.
+
+### 3. Missing Tag Definitions
+
+*   **Crowd Control:** Several tags listed in `TAG_SYSTEM_IMPLEMENTATION.md` (`Immobilize`, `Banish`, `Displacement`, `Knockback`, `Knockdown`, `Grab`) are **not defined** in `constants.ts`. These need to be defined to be used.
+
+### 4. Redundancy or Clarity Issues
+
+*   **Defensive Tags:** `Counter` vs. `Retaliate`; `Reflect` vs. `DamageReflection`; `Absorb` vs. `Absorption`. These pairs need review for redundancy. One of each pair might be sufficient or needs clearer distinction.
+*   **Resource Mechanics:** `Channel_Health` vs. `Blood_Magic` are very similar and need clear differentiation or consolidation.
+*   **Placeholder Tags:** Generic tags like `DefensiveBuff`, `OffensiveBuff`, `Debuff`, `Control` have high game precedence due to their file order but lack specific mechanics. Their use on gameplay-affecting spells should be avoided or their definitions refined and precedence lowered.
+
+## Implementation Status in `CombatEngine.ts` (Initial Observations)
+
+A full verification of every tag in `CombatEngine.ts` was not completed, but initial review shows:
+
+*   Many core tags related to damage calculation, basic targeting, and some resource mechanics ARE implemented (e.g., `Critical`, `Piercing`, `Armor_Ignoring`, `True_Damage`, `Lifesteal`, `Vampiric`, `Reduced_Cost`, `Blood_Magic`, targeting types like `SingleTarget`, `AreaOfEffect`, etc.).
+*   Several tags have `// TODO` comments or lack explicit handling in `CombatEngine.ts` despite being defined (e.g., `Shield`, `Enhancement`, and likely many specific CCs, Buffs, Debuffs beyond generic stat changes).
+*   The behavior of implemented tags needs to be compared against their `powerLevel` and `description` in `TAG_DEFINITIONS` to ensure consistency.
+
+## General Recommendations
+
+1.  **Systematic Reordering in `constants.ts`:** Adjust tag order to fix precedence issues, especially for tiered effects and rarities.
+2.  **Add Missing `conflictsWith`:** Ensure mutually exclusive tags correctly conflict.
+3.  **Define Missing Tags:** Add documented but undefined tags (especially CCs).
+4.  **Resolve Redundancies:** Consolidate or clearly differentiate similar tags.
+5.  **Refine or Relocate Placeholder Tags:** Avoid using generic tags with high precedence for specific spell effects.
+6.  **Implement Tag Logic in `CombatEngine.ts`:** Add game mechanics for defined tags that currently have no effect.
+7.  **Thorough Testing:** All changes require extensive testing.
+
+This report should guide further refactoring and bug fixing efforts for the tag system.


### PR DESCRIPTION
I reordered True_Damage, Armor_Ignoring, and Piercing tags to ensure logical precedence (True_Damage > Armor_Ignoring > Piercing). I also reordered Devastating, Brutal, and Overwhelming tags similarly (Devastating > Brutal > Overwhelming). I updated conflictsWith properties for these tags to ensure correct behavior and removal of lower-precedence conflicting tags.

Feat: Add bugreporting.md for Tag System.

I created a new file documentation/bugreporting.md which contains a detailed summary of the analysis performed on the game's tag system. This report includes:
- Other identified precedence issues (Rarity, Tiered Debuffs, etc.).
- Missing conflict definitions for various tag categories.
- Missing tag definitions (e.g., several Crowd Control tags).
- Potential tag redundancies and clarity issues.
- Recommendations for further refactoring and implementation in CombatEngine.ts.