### PR TITLE
Fix: Ensure GIFs are visible on hover for non-camp ActivityCards

### DIFF
--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -70,7 +70,13 @@ const ActivityCard: React.FC<ActivityCardProps> = ({
         }}
       >
         {/* Enhanced Background Illustration with Ambient Effects */}
-        <div className={`absolute inset-0 ${isCampCard ? 'opacity-70' : 'opacity-0 group-hover:opacity-20'} transition-all duration-500 rounded-lg overflow-hidden`}>
+        <div className={`absolute inset-0 ${
+      isCampCard
+      ? 'opacity-70'
+      : (isHovered && currentBackgroundImage === gifBackgroundImage && gifBackgroundImage)
+        ? 'opacity-70'
+        : 'opacity-0 group-hover:opacity-20'
+    } transition-all duration-500 rounded-lg overflow-hidden`}>
           <div className={`w-full h-full ${isCampCard ? 'bg-amber-900/20' : `bg-gradient-to-br ${color.replace('/20', '/40')}`} rounded-lg overflow-hidden`}>
             {/* Unified image rendering logic */}
             <div className="relative w-full h-full">


### PR DESCRIPTION
Previously, ActivityCards other than 'camp' (such as 'Quest Log', 'NPCs & Quests', 'Trading Hub', 'Research', 'Crafting') had their GIF backgrounds rendered almost invisibly on hover. This was due to the shared background container having a very low opacity (`opacity-0 group-hover:opacity-20`) intended for subtle SVG display, which also affected the GIF.

This commit modifies `ActivityCard.tsx` to adjust the opacity of the background image container. The logic now ensures that if a card is hovered and its `gifBackgroundImage` is active, the container's opacity is increased to `opacity-70` (matching the 'camp' card's behavior). This makes the GIFs for all relevant cards clearly visible on hover as intended. Static SVG backgrounds on non-camp cards will retain their subtle hover effect when no GIF is active.