### PR TITLE
Fix: Ensure 'Progression' tab appears in CharacterSheetModal

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1104,6 +1104,7 @@ export const App: React.FC = () => {
     getPreparedAbilities,
     checkResources,
     renderResourceList,
+    onUpdatePlayer: handleCharacterCreation,
   };
 
   return (

--- a/game-graphics/AppShell.tsx
+++ b/game-graphics/AppShell.tsx
@@ -12,7 +12,7 @@ import { FIRST_TRAIT_LEVEL, TRAIT_LEVEL_INTERVAL } from '../constants';
 // Import layout and modal components
 import MainLayout from '../src/layouts/MainLayout';
 import Modal from '../src/components/Modal';
-import { CharacterSheetModal } from '../src/CharacterSheetModal.ancient';
+import { CharacterSheetModal } from '../src/components/CharacterSheetModal-elemets';
 import HelpWikiModal from '../src/components/HelpWikiModal';
 import GameMenuModal from '../src/components/GameMenuModal';
 import MobileMenuModal from '../src/components/MobileMenuModal';
@@ -67,6 +67,7 @@ export interface AppShellProps {
   onUnprepareAbility: (ability: Ability) => void;
   onOpenLootChest: (chestId: string) => Promise<void>;
   onUseConsumable: (itemId: string, targetId: string | null) => void;
+  onUpdatePlayer?: (updater: (prev: Player) => Player) => void;
   
   // Navigation handlers
   onNavigateHome: () => void;
@@ -156,6 +157,7 @@ const AppShell: React.FC<AppShellProps> = (props) => {
     onUnprepareAbility,
     onOpenLootChest,
     onUseConsumable,
+    onUpdatePlayer,
     
     // Modal close handlers
     onCloseModal,
@@ -348,6 +350,7 @@ const AppShell: React.FC<AppShellProps> = (props) => {
           canCraftNewTrait={canCraftNewTrait} 
           onOpenLootChest={onOpenLootChest} 
           onUseConsumableFromInventory={onUseConsumable}
+          onUpdatePlayer={onUpdatePlayer}
         />
       )}
 


### PR DESCRIPTION
The 'Progression' tab was not appearing because the application was importing and using an outdated version of the CharacterSheetModal (`CharacterSheetModal.ancient.tsx`) which did not include this tab.

This commit updates `game-graphics/AppShell.tsx` to import the correct, refactored `CharacterSheetModal` from
`src/components/CharacterSheetModal-elemets/index.tsx`.

Additionally, the `onUpdatePlayer` prop, required for the character recreation functionality within the 'Progression' tab, has been passed down from `App.tsx` through `AppShell.tsx` to the `CharacterSheetModal`.